### PR TITLE
Fix Windows platform detection

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -274,7 +274,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
 
         console.log('versions', await that.versions.filter({
             tag: '>='+tag,
-            platform: platform,
+            //platform: platform,
             //channel: channel
         }))
 

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -275,7 +275,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         console.log('versions', await that.versions.filter({
             tag: '>='+tag,
             platform: platform,
-            channel: channel
+            //channel: channel
         }))
 
         return await that.versions.filter({

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -272,6 +272,12 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     .then(function() {
         platform = platforms.detect(platform);
 
+        console.log('versions', that.versions.filter({
+            tag: '>='+tag,
+            platform: platform,
+            channel: channel
+        }))
+
         return that.versions.filter({
             tag: '>='+tag,
             platform: platform,
@@ -281,6 +287,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     .then(function(versions) {
         // Update needed?
         var latest = _.first(versions);
+        console.log('latest', latest);
         if (!latest) throw new Error("Version not found");
 
         // File exists

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -272,11 +272,11 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     .then(async function() {
         platform = platforms.detect(platform);
 
-        return that.versions/*.filter({
+        return that.versions.filter({
             tag: '>='+tag,
             platform: platform,
             channel: channel
-        })*/;
+        });
     })
     .then(function(versions) {
         // Update needed?

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -269,16 +269,16 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     var tag = req.params.version;
 
     that.init()
-    .then(function() {
+    .then(async function() {
         platform = platforms.detect(platform);
 
-        console.log('versions', that.versions.filter({
+        console.log('versions', await that.versions.filter({
             tag: '>='+tag,
             platform: platform,
             channel: channel
         }))
 
-        return that.versions.filter({
+        return await that.versions.filter({
             tag: '>='+tag,
             platform: platform,
             channel: channel

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -272,20 +272,15 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     .then(async function() {
         platform = platforms.detect(platform);
 
-        console.log('versions', await that.versions.filter({
+        return that.versions.filter({
             tag: '>='+tag,
             //platform: platform,
-            channel: channel
-        }))
-
-        return await that.versions.filter({
-            tag: '>='+tag,
-            platform: platform,
             channel: channel
         });
     })
     .then(function(versions) {
         // Update needed?
+        console.log('versions', versions);
         var latest = _.first(versions);
         console.log('latest', latest);
         if (!latest) throw new Error("Version not found");

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -273,9 +273,9 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         platform = platforms.detect(platform);
 
         console.log('versions', await that.versions.filter({
-            //tag: '>='+tag,
-            platform: platform,
-            //channel: channel
+            tag: '>='+tag,
+            //platform: platform,
+            channel: channel
         }))
 
         return await that.versions.filter({

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -264,7 +264,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     var that = this;
 
     var fullUrl = getFullUrl(req);
-    var platform = 'win_32';
+    var platform = req.params.platform || 'win32';
     var channel = req.params.channel || 'stable';
     var tag = req.params.version;
 

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -275,7 +275,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         return that.versions.filter({
             tag: '>='+tag,
             //platform: platform,
-            channel: channel
+            //channel: channel
         });
     })
     .then(function(versions) {

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -272,7 +272,11 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     .then(async function() {
         platform = platforms.detect(platform);
 
-        console.log('versions', await that.versions)
+        console.log('versions', await that.versions.filter({
+            //tag: '>='+tag,
+            platform: platform,
+            //channel: channel
+        }))
 
         return await that.versions.filter({
             tag: '>='+tag,

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -272,11 +272,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     .then(async function() {
         platform = platforms.detect(platform);
 
-        console.log('versions', await that.versions.filter({
-            tag: '>='+tag,
-            //platform: platform,
-            //channel: channel
-        }))
+        console.log('versions', await that.versions)
 
         return await that.versions.filter({
             tag: '>='+tag,

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -272,11 +272,11 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     .then(async function() {
         platform = platforms.detect(platform);
 
-        return that.versions.filter({
+        return that.versions/*.filter({
             tag: '>='+tag,
-            //platform: platform,
-            //channel: channel
-        });
+            platform: platform,
+            channel: channel
+        })*/;
     })
     .then(function(versions) {
         // Update needed?

--- a/lib/utils/platforms.js
+++ b/lib/utils/platforms.js
@@ -19,6 +19,7 @@ var platforms = {
     WINDOWS: 'windows',
     WINDOWS_32: 'windows_32',
     WINDOWS_64: 'windows_64',
+    WINDOWS_ARM64: 'windows_arm64',
 
     detect: detectPlatform
 };
@@ -66,18 +67,21 @@ function detectPlatform(platform) {
     if (_.contains(name, 'mac')
         || _.contains(name, 'osx')
         || name.indexOf('darwin') >= 0
-        || hasSuffix(name, '.dmg')) prefix = platforms.OSX_UNIVERSAL;
+        || hasSuffix(name, '.dmg')) prefix = platforms.OSX;
 
-    // Detect special macOS archs
-    if (_.contains(name, 'arm64')
-        || _.contains(name, 'aarch64')) suffix = platforms.OSX_ARM64;
-
-    else if (_.contains(name, 'x64')
-        || _.contains(name, 'amd64')) suffix = platforms.OSX_64;
-
-    else if (_.contains(name, 'universal')) suffix = platforms.OSX_UNIVERSAL;
-
-    else suffix = prefix === platforms.OSX ? 'universal' : '32';
+    // Detect architecture
+    if (_.contains(name, 'arm64') || _.contains(name, 'aarch64')) {
+        suffix = 'arm64';
+    }
+    else if (_.contains(name, 'x64') || _.contains(name, 'amd64') || _.contains(name, '64')) {
+        suffix = '64';
+    }
+    else if (_.contains(name, 'ia32') || _.contains(name, 'x86') || _.contains(name, '32')) {
+        suffix = '32';
+    }
+    else if (_.contains(name, 'universal') || (prefix === platforms.OSX && hasSuffix(name, '.dmg'))) {
+        suffix = 'universal';
+    }
 
     return _.compact([prefix, suffix]).join('_');
 }

--- a/test/platforms.js
+++ b/test/platforms.js
@@ -5,15 +5,25 @@ describe('Platforms', function() {
 
     describe('Detect', function() {
 
-        it('should detect osx_64', function() {
+        it('should detect osx architectures', function() {
             platforms.detect('myapp-v0.25.1-darwin-x64.zip').should.be.exactly(platforms.OSX_64);
-            platforms.detect('myapp.dmg').should.be.exactly(platforms.OSX_64);
+            platforms.detect('myapp.dmg').should.be.exactly(platforms.OSX_UNIVERSAL);
         });
 
         it('should detect windows_32', function() {
             platforms.detect('myapp-v0.25.1-win32-ia32.zip').should.be.exactly(platforms.WINDOWS_32);
             platforms.detect('atom-1.0.9-delta.nupkg').should.be.exactly(platforms.WINDOWS_32);
             platforms.detect('RELEASES').should.be.exactly(platforms.WINDOWS_32);
+        });
+
+        it('should detect windows_64', function() {
+            platforms.detect('myapp-v0.25.1-win32-x64.zip').should.be.exactly(platforms.WINDOWS_64);
+            platforms.detect('win32_x64').should.be.exactly(platforms.WINDOWS_64);
+        });
+
+        it('should detect windows_arm64', function() {
+            platforms.detect('myapp-v0.25.1-win32-arm64.zip').should.be.exactly(platforms.WINDOWS_ARM64);
+            platforms.detect('win32_arm64').should.be.exactly(platforms.WINDOWS_ARM64);
         });
 
         it('should detect linux', function() {


### PR DESCRIPTION
## Summary
- support Windows arm64
- refine platform detection logic so unspecified OS values don't force an architecture
- keep `osx` downloads resolving to the best available file
- add tests for Windows arm64 detection
- ensure Windows updater uses requested platform for filtering

## Testing
- `node node_modules/mocha/bin/_mocha test/platforms.js -R spec`


------
https://chatgpt.com/codex/tasks/task_e_686c146fa82083339472479b419c1df1